### PR TITLE
Replace `=` with `=>` in the `match` structure

### DIFF
--- a/src/control_flow.md
+++ b/src/control_flow.md
@@ -140,9 +140,9 @@ match x {
 
 ```text
 match VALUE {
-    PATTERN = EXPRESSION,
-    PATTERN = EXPRESSION,
-    PATTERN = EXPRESSION,
+    PATTERN => EXPRESSION,
+    PATTERN => EXPRESSION,
+    PATTERN => EXPRESSION,
 }
 ```
 


### PR DESCRIPTION
It looks like it should be `=>` here? 

I've tested it with the following commands:
`mdbook build`
`mdbook serve --open`
— and the web browser displays the `=>` symbols as expected.